### PR TITLE
change incorrect reference from 'kanji' to 'katakana'

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install -g matrix-rain
 ```
 usage: matrix-rain [-h] [-v] [-d {h,v}]
                 [-c {green,red,blue,yellow,magenta,cyan,white}]
-                [-k {ascii,binary,braille,emoji,kanji}] [-f FILEPATH]
+                [-k {ascii,binary,braille,emoji,katakana}] [-f FILEPATH]
 
 
 The famous Matrix rain effect of falling green characters as a cli command
@@ -24,7 +24,7 @@ Optional arguments:
                         Change direction of rain. h=horizontal, v=vertical
   -c , --color {green,red,blue,yellow,magenta,cyan,white}
                         Rain color. NOTE: droplet start is always white
-  -k, --char-range {ascii,binary,braille,emoji,kanji}
+  -k, --char-range {ascii,binary,braille,emoji,katakana}
                         Use rain characters from char-range
   -f, --file-path FILEPATH
                         Read characters from a file instead of random

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const argParser = new ArgumentParser({
   {
     flags: [ `-k`, `--char-range` ],
     opts: {
-      choices: [`ascii`, `binary`, `braille`, `emoji`, `kanji`],
+      choices: [`ascii`, `binary`, `braille`, `emoji`, `katakana`],
       defaultValue: `ascii`,
       dest: `charRange`,
       help: `Use rain characters from char-range.`,
@@ -96,7 +96,7 @@ class MatrixRain {
       for (let i = 0; i < len; i++) {
         chars[i] = String.fromCharCode(rand(0x2840, 0x28ff));
       }
-    } else if (charRange === `kanji`) {
+    } else if (charRange === `katakana`) {
       for (let i = 0; i < len; i++) {
         chars[i] = String.fromCharCode(rand(0x30a0, 0x30ff));
       }


### PR DESCRIPTION
The characters that currently show up when a user elects to use the `kanji` option are not actually kanji (the Chinese characters used in the Japanese writing system), but rather katakana (one of the Japanese phonetic alphabets). 

("Kangxi" radicals are in the unicode spec from 0x2F00-0x2FDF)