### PR TITLE
Binary option fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,10 @@ class MatrixRain {
       for (let i = 0; i < len; i++) {
         chars[i] = String.fromCharCode(rand(0x21, 0x7E));
       }
+    } else if (charRange === `binary`) {
+      for (let i = 0; i < len; i++) {
+        chars[i] = String.fromCharCode(rand(0x30, 0x32));
+      }
     } else if (charRange === `braille`) {
       for (let i = 0; i < len; i++) {
         chars[i] = String.fromCharCode(rand(0x2840, 0x28ff));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-rain",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "The famous Matrix rain effect of falling green characters as a cli command",
   "main": "index.js",
   "preferGlobal": true,


### PR DESCRIPTION
Running `matrix-rain -k binary` does not rain. This pull request fixes it.